### PR TITLE
Add "master" to infractions.yml and improve CI test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,5 +32,8 @@ jobs:
     - name: Bundle install
       run: bundle install
 
-    - name: Run tests
+    - name: Validate infractions are YAML
       run: bundle exec rake parse_data_file
+
+    - name: Validate data completeness
+      run: bundle exec rake validate_data

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,18 @@ task :parse_data_file do
   infractions_file = File.join(__dir__, 'infractions.yml')
   YAML.parse(File.read(infractions_file))
 end
+
+# Ensures that each item in infractions.yml has at least one term and alternative.
+task :validate_data do
+  require 'yaml'
+  infractions_file = File.join(__dir__, 'infractions.yml')
+  infractions = YAML.load(File.read(infractions_file))
+  error_message = ''
+  if infractions.any? { |i| i['terms'].nil? || i['terms'].empty? }
+    error_message += 'Each infraction must contain at least one term.'
+  end
+  if infractions.any? { |i| i['alternatives'].nil? || i['alternatives'].empty? }
+    error_message += 'Each infraction must contain at least one alternative.'
+  end
+  raise error_message unless error_message.empty?
+end

--- a/infractions.yml
+++ b/infractions.yml
@@ -47,3 +47,8 @@
   - slave
   alternatives:
   - replica
+- terms:
+  - master
+  alternatives:
+  - primary
+  - main


### PR DESCRIPTION
https://github.com/airbnb/inclusion/pull/11 made us aware that we should include "master" in our list of infractions as well, along with "slave". Both of these terms are non-inclusive when used to establish a hierarchical relationship between entities or nodes.

While I was here I added a simple CI check that each new entry we add to infractions.yml includes at least one term and alternative.

When this PR is merged I will bump the version to 0.2.0 since we have added a new term.

@airbnb/inclusion-repo-maintainers @teddywilson