### PR TITLE
Use central Airbnb Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-Airbnb has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full Code of Conduct text](https://airbnb.io/codeofconduct/) so that you can understand what actions will and will not be tolerated. Report violations to the maintainers of this project or to [opensource-conduct@airbnb.com](mailto:opensource-conduct@airbnb.com).
-
-Reports sent to [opensource-conduct@airbnb.com](mailto:opensource-conduct@airbnb.com) are received by Airbnb's open source code of conduct moderation team, which is composed of Airbnb employees. All communications are private and confidential.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ We are publicly sharing `infractions.yml`. `infractions.yml` is a data file of t
 The data file format is agnostic to any particular tool and is meant to be general enough to be adapted to any tool.
 
 ## Contributing
-Please open an issue on this GitHub repository. Contributors are expected to follow the [Code of Conduct](./CODE_OF_CONDUCT.md).
+Please open an issue on this GitHub repository. Contributors are expected to follow the [Code of Conduct](https://github.com/airbnb/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
The magical https://github.com/airbnb/.github/blob/main/CODE_OF_CONDUCT.md allows the Airbnb code of conduct to propagate to all repos within the organization. Let's rely on that to avoid getting out of sync.

Thanks @lencioni for the tip.

@airbnb/inclusion-repo-maintainers 